### PR TITLE
workaround: replay cached initialize handshake on reconnect

### DIFF
--- a/django_mcp/mcp_sdk_session_replay.py
+++ b/django_mcp/mcp_sdk_session_replay.py
@@ -1,0 +1,83 @@
+import asyncio
+import collections
+import json
+import logging
+from uuid import UUID
+
+from django.core.cache import cache
+from mcp.server.sse import SseServerTransport
+from mcp.types import JSONRPCNotification, JSONRPCMessage
+
+from .log import logger
+
+
+async def try_replay_session_initialize(sse: SseServerTransport, session_id: str, cache_slug: str):
+    # Replay any cached initialize messages in case of server restart / non-sticky load balancing
+    # Some clients like @modelcontextprotocol/inspector and Cursor may not send `initialize` message
+    # on a re-connect even when new session_id is returned, so we need to replay cached messages
+    logger.debug(f'(try_replay_session_initialize) Attempting to replay initialize for session {session_id} with cache slug {cache_slug}')
+    writer = sse._read_stream_writers.get(UUID(session_id))
+    if writer is None:
+        logger.warning(f"(try_replay_session_initialize) No stream writer found for session {session_id}")
+        logger.debug(str(sse._read_stream_writers))
+        return
+
+    for method in ('initialize', 'notifications/initialized'):
+        cache_key = f'mcp:{method}:{cache_slug}'
+        try:
+            cached_json = cache.get(cache_key)
+            if cached_json:
+                payload = json.loads(cached_json)
+                payload['_synthetic'] = True
+                payload['_replay'] = True
+                from mcp.types import JSONRPCMessage
+                replay_msg = JSONRPCMessage.model_validate_json(json.dumps(payload))
+                await writer.send(replay_msg)
+                logger.debug(f"Replayed cached '{method}' for: {cache_slug}\n\t{payload}")
+        except Exception as e:
+            logger.warning(f"Failed to replay '{method}' for {cache_slug}: {e}")
+
+
+class SseReadStreamProxy:
+    def __init__(self, wrapped, cache_slug: str, ttl_seconds: int = 3600):
+        self._wrapped = wrapped
+        self._cache_slug = cache_slug
+        self._ttl_seconds = ttl_seconds
+        self._initialized = False
+
+    async def receive(self):
+        msg = await self._wrapped.receive()
+        if hasattr(msg, "root"):
+            method = getattr(msg.root, "method", None)
+            if method in ("initialize", "notifications/initialized"):
+                try:
+                    data = msg.model_dump(mode="json", by_alias=True, exclude_none=True)
+                    if data.get("_synthetic", False):
+                        logger.debug(f"Skipping caching synthetic {method} message")
+                        return msg
+                    key = f"mcp:{method}:{self._cache_slug}"
+                    cache.set(key, json.dumps(data), timeout=self._ttl_seconds)
+                    logger.debug(f"Cached {method} request under key: {key}")
+                except Exception as e:
+                    logger.warning(f"Failed to cache {method} message: {e}")
+        return msg
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            message = await self.receive()
+        except (StopAsyncIteration, GeneratorExit):
+            raise StopAsyncIteration
+        return message
+
+    async def aclose(self):
+        await self._wrapped.aclose()
+
+    async def __aenter__(self):
+        await self._wrapped.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self._wrapped.__aexit__(exc_type, exc_val, exc_tb)


### PR DESCRIPTION
Adds `SseReadStreamProxy` and `try_replay_session_initialize` to cache and replay MCP `initialize` and `notifications/initialized` messages. This avoids broken sessions after server restart or load balancer shuffle where RAM-only session state is lost or otherwise not shared across load-balanced instances.

The specific [modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk) exception it should mitigate is:

```python
RuntimeError: Received request before initialization was complete
```

Closes #1