### PR TITLE
fix(sse): migrate to ASGI class view to resolve TaskGroup cancellation error

### DIFF
--- a/django_mcp/mcp_sdk_session_replay.py
+++ b/django_mcp/mcp_sdk_session_replay.py
@@ -3,6 +3,7 @@ import collections
 import json
 import logging
 from uuid import UUID
+import anyio
 
 from django.core.cache import cache
 from mcp.server.sse import SseServerTransport
@@ -72,6 +73,11 @@ class SseReadStreamProxy:
     async def __anext__(self):
         try:
             message = await self.receive()
+        except anyio.EndOfStream:
+            # The underlying anyio stream (self._wrapped) has ended.
+            # Convert this to StopAsyncIteration to conform to the
+            # Python asynchronous iterator protocol.
+            raise StopAsyncIteration
         except (StopAsyncIteration, GeneratorExit):
             raise StopAsyncIteration
         return message


### PR DESCRIPTION
This Pull Request addresses an issue where unhandled anyio.EndOfStream exceptions during Server-Sent Event (SSE) connection termination could lead to ExceptionGroup: unhandled errors in a TaskGroup errors being logged by Uvicorn/Starlette. This typically occurs when an SSE client (e.g., n8n MCP node) disconnects.


The key changes are:
**1. Refactor SSE handler to a dedicated ASGI application (SsePatchedApp):**
- The previous handle_sse async function, when used with Starlette's routing, was treated as a request_response endpoint. This mode is less suitable for the long-lived nature of SSE connections and doesn't inherently manage stream termination exceptions like anyio.EndOfStream gracefully at the ASGI level.

- By refactoring handle_sse into an ASGI application class (SsePatchedApp implementing async def __call__(self, scope, receive, send)), we allow Starlette to treat it as a raw ASGI endpoint. This gives us more direct control over the connection lifecycle and ensures that the application naturally terminates when the underlying MCP server run and SSE transport context managers complete, without leaking TaskGroup exceptions upwards.

**2. Correctly handle anyio.EndOfStream in SseReadStreamProxy.__anext__:**
  - The SseReadStreamProxy is used by the mcp-sdk's Session._receive_loop as an async iterator (async for message in self._read_stream:).
  - Previously, if self._wrapped.receive() (the underlying anyio stream) raised anyio.EndOfStream, it would propagate out of __anext__ and be caught by the mcp-sdk's internal TaskGroup, leading to the ExceptionGroup error.
  - This change modifies SseReadStreamProxy.__anext__ to explicitly catch anyio.EndOfStream and raise StopAsyncIteration instead. This conforms to Python's asynchronous iterator protocol and allows the mcp-sdk's _receive_loop to terminate cleanly.

Impact of Changes:
  - Resolves ExceptionGroup errors: Prevents these errors from appearing in server logs when SSE clients disconnect.

Related Issue:
- [Bug: SSE connection via handle_sse (async def) results in unhandled TaskGroup error on stream end](https://github.com/kitespark/django-mcp/issues/5)

Reference:
#5
https://github.com/encode/starlette/blob/master/starlette/routing.py#L228
https://github.com/nerding-io/n8n-nodes-mcp/blob/main/nodes/McpClient/McpClient.node.ts
https://github.com/modelcontextprotocol/typescript-sdk